### PR TITLE
Change owner of dolibarr directory

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -232,7 +232,7 @@ ynh_store_file_checksum --file="$final_path/htdocs/conf/conf.php"
 #=================================================
 
 # Set permissions on app files
-chown -R root: "$final_path"
+chown -R $app: "$final_path"
 chmod 644 "$final_path/htdocs/conf/conf.php"
 mkdir -p "$datadir"
 chown -R $app: "$datadir"

--- a/scripts/restore
+++ b/scripts/restore
@@ -106,7 +106,7 @@ ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 #=================================================
 
 # Set permissions on app files
-chown -R root: "$final_path"
+chown -R $app: "$final_path"
 chmod 644 "$final_path/htdocs/conf/conf.php"
 mkdir -p "$datadir"
 chown -R $app: "$datadir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -215,7 +215,7 @@ ynh_use_logrotate --non-append
 #=================================================
 
 # Set permissions on app files
-chown -R root: "$final_path"
+chown -R $app: "$final_path"
 chmod 644 "$final_path/htdocs/conf/conf.php"
 mkdir -p "$datadir"
 chown -R $app: "$datadir"


### PR DESCRIPTION
/var/www/dolibarr needs to be owned by `dolibarr` user.

See https://github.com/YunoHost-Apps/dolibarr_ynh/issues/39