### PR TITLE
Permissions api public

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -103,6 +103,10 @@ ram.runtime = "150M"
     [resources.permissions]
     main.url = "/"
 
+    api.url = "/api"
+    api.allowed = "visitors"
+    api.protected = false
+
     [resources.apt]
     packages = [
         "php8.3-mysql",

--- a/manifest.toml
+++ b/manifest.toml
@@ -46,10 +46,10 @@ ram.runtime = "150M"
     type = "user"
 
 [resources]
+
     [resources.sources.main]
     url = "https://github.com/Dolibarr/dolibarr/archive/refs/tags/19.0.3.tar.gz"
     sha256 = "52fcea5a354f8688fa328abffaa196bf9056f545164cd7fe882d1bb7de654163"
-    autoupdate.strategy = "latest_github_release"
 
     [resources.sources.main_18_0_1]
     url = "https://github.com/dolibarr/dolibarr/archive/18.0.1.tar.gz"

--- a/manifest.toml
+++ b/manifest.toml
@@ -46,10 +46,10 @@ ram.runtime = "150M"
     type = "user"
 
 [resources]
-
     [resources.sources.main]
     url = "https://github.com/Dolibarr/dolibarr/archive/refs/tags/19.0.3.tar.gz"
     sha256 = "52fcea5a354f8688fa328abffaa196bf9056f545164cd7fe882d1bb7de654163"
+    autoupdate.strategy = "latest_github_release"
 
     [resources.sources.main_18_0_1]
     url = "https://github.com/dolibarr/dolibarr/archive/18.0.1.tar.gz"

--- a/manifest.toml
+++ b/manifest.toml
@@ -106,6 +106,12 @@ ram.runtime = "150M"
     api.url = "/api"
     api.allowed = "visitors"
     api.protected = false
+    api.show_tile = false
+
+    public.url = "/public"
+    public.allowed = "visitors"
+    public.protected = false
+    public.show_tile = false
 
     [resources.apt]
     packages = [

--- a/scripts/install
+++ b/scripts/install
@@ -79,8 +79,8 @@ ynh_exec_fully_quiet sleep 5
 
 # Setup HTTP auth in conf
 ynh_replace_string --target_file="$install_dir/htdocs/conf/conf.php" \
-    --match_string="dolibarr_main_authentication='dolibarr'" \
-    --replace_string="dolibarr_main_authentication='http'"
+    --match_string="\$dolibarr_main_authentication='dolibarr';" \
+    --replace_string="\$dolibarr_main_authentication='http,ldap';\n\$dolibarr_main_auth_ldap_host='127.0.0.1';\n\$dolibarr_main_auth_ldap_port='389';\n\$dolibarr_main_auth_ldap_version='3';\n\$dolibarr_main_auth_ldap_servertype='openldap';\n\$dolibarr_main_auth_ldap_dn='ou=users,dc=yunohost,dc=org';\n\$dolibarr_main_auth_ldap_login_attribute='uid';"
 
 # Calculate and store the config file checksum into the app settings
 ynh_store_file_checksum --file="$install_dir/htdocs/conf/conf.php"

--- a/scripts/install
+++ b/scripts/install
@@ -79,8 +79,8 @@ ynh_exec_fully_quiet sleep 5
 
 # Setup HTTP auth in conf
 ynh_replace_string --target_file="$install_dir/htdocs/conf/conf.php" \
-    --match_string="\$dolibarr_main_authentication='dolibarr';" \
-    --replace_string="\$dolibarr_main_authentication='http,ldap';\n\$dolibarr_main_auth_ldap_host='127.0.0.1';\n\$dolibarr_main_auth_ldap_port='389';\n\$dolibarr_main_auth_ldap_version='3';\n\$dolibarr_main_auth_ldap_servertype='openldap';\n\$dolibarr_main_auth_ldap_dn='ou=users,dc=yunohost,dc=org';\n\$dolibarr_main_auth_ldap_login_attribute='uid';"
+    --match_string="dolibarr_main_authentication='dolibarr'" \
+    --replace_string="dolibarr_main_authentication='http'"
 
 # Calculate and store the config file checksum into the app settings
 ynh_store_file_checksum --file="$install_dir/htdocs/conf/conf.php"


### PR DESCRIPTION
## Problem

- When access to the application is not set to ‘visitors’, access to the api or to dolibarr's public functions (calendar, tickets) is not possible.

## Solution

- added separate permissions for /api and /public

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
